### PR TITLE
update [compat] bump minor version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FredApi"
 uuid = "1f615318-737c-46ca-9fde-6231706b5dcc"
 authors = ["markushhh <markushhh.jl@gmail.com>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
@@ -11,9 +11,9 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 TimeSeries = "9e3dc215-6440-5c97-bce1-76c03772f85e"
 
 [compat]
-DataFrames = "0.17, 0.18, 0.19, 0.20, 0.21, 0.22"
-Dates = "1.2"
-HTTP = "0.7, 0.8"
+DataFrames = "0.17, 0.18, 0.19, 0.20, 0.21, 0.22, 1.0"
+HTTP = "0.7, 0.8, 0.9"
 JSON = "0.19, 0.20, 0.21"
-TimeSeries = "0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.20"
+TimeSeries = "0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23"
 julia = "1.0"
+


### PR DESCRIPTION
The versions in [compat] for DataFrames TimeSeries and one other were out of date, so adding this package forced other packages to downgrade.  This PR brings [compat] up do date and increases the minor version number.